### PR TITLE
Add `.travis.yml` for build testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,82 @@
+language: cpp
+
+osx_image: xcode8.3
+
+matrix:
+  include:
+  - os: linux
+    dist: trusty
+    sudo: required
+    compiler: gcc
+    env:
+    - QT_MAJOR=5
+    - QT_MINOR=9
+    - PROJECT=Engine
+    - BINARY=Engine
+  - os: linux
+    dist: trusty
+    sudo: required
+    compiler: gcc
+    env:
+    - QT_MAJOR=5
+    - QT_MINOR=9
+    - PROJECT=Game
+    - BINARY=Game
+  - os: osx
+    compiler: clang
+    env:
+    - QT_MAJOR=5
+    - QT_MINOR=9
+    - PROJECT=Engine
+    - BINARY=Engine.app
+  - os: osx
+    compiler: clang
+    env:
+    - QT_MAJOR=5
+    - QT_MINOR=9
+    - PROJECT=Game
+    - BINARY=Game.app
+
+before_install:
+- export QT_FULL="${QT_MAJOR}${QT_MINOR}"
+- |
+  if [ "$CXX" = "g++" ]; then
+    sudo add-apt-repository -y ppa:beineri/opt-qt${QT_FULL}-trusty
+    sudo apt-get update -qq
+    sudo apt-get install -qq qt${QT_FULL}base qt${QT_FULL}declarative
+  fi
+- |
+  if [ "$CXX" = "clang++" ]; then
+    brew update
+    brew install qt${QT_MAJOR} swift
+  fi
+
+install:
+- export QT_SELECT=qt${QT_MAJOR}
+- $CXX --version
+- |
+  if [ "$CXX" = "g++" ]; then
+    . /opt/qt${QT_FULL}/bin/qt${QT_FULL}-env.sh
+  fi
+- |
+  if [ "$CXX" = "clang++" ]; then
+    brew link --force qt${QT_MAJOR}
+  fi
+
+script:
+- qmake -r "QMAKE_CXX=$CXX" "QMAKE_CC=$CC" -v
+- cd "${PROJECT}"
+- qmake -r "QMAKE_CXX=$CXX" "QMAKE_CC=$CC"
+- make
+- make -k check
+
+deploy:
+  provider: releases
+  api_key:
+    secure: "${RELEASES_API_KEY}"
+  file: "${PROJECT}/${BINARY}"
+  skip_cleanup: true
+  overwrite: true
+  on:
+    repo: afaur/RPG-Paper-Maker
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,5 +78,5 @@ deploy:
   skip_cleanup: true
   overwrite: true
   on:
-    repo: afaur/RPG-Paper-Maker
+    repo: Wano-k/RPG-Paper-Maker
     tags: true


### PR DESCRIPTION
This will add support for Travis-CI after it is enabled for this repository. 
The steps required to get this enabled for the repository are...

- Browse to [Travis-CI](http://www.travis-ci.org)
- Click `sign in with github` link in top right corner
- Once you are logged in hover over the top right area and click on `accounts` <img width="153" alt="menu" src="https://user-images.githubusercontent.com/898523/28070404-a7cd4950-6601-11e7-8f96-ad41f09723a7.png">
- You may need to click `sync from github` depending on if you see `RPG-Paper-Maker` listed
- Once you locate the repository click the toggle slider to enable it <img width="312" alt="toggle" src="https://user-images.githubusercontent.com/898523/28070482-edd047e0-6601-11e7-9351-618739a64475.png">
- Now click the cog button <img width="36" alt="cog" src="https://user-images.githubusercontent.com/898523/28070518-0da0bf64-6602-11e7-95a0-cf3ec4746610.png">
- I changed to these settings because building branch updates and PR updates seemed redundant <img width="1062" alt="settings" src="https://user-images.githubusercontent.com/898523/28070558-2ebdffae-6602-11e7-8481-35677658194b.png">
- Scroll down to environment variables <img width="1067" alt="environment" src="https://user-images.githubusercontent.com/898523/28070626-76036a16-6602-11e7-8e1e-ffc38a8cee25.png">
- [PENDING TESTING] You will need to add an environment variable labeled `RELEASES_API_KEY` with a value of an encrypted api key for github. 
  - This step is only needed for automated publishing of `linux` and `osx` binaries to the github `releases` page
  - Here is a guide (https://docs.travis-ci.com/user/encryption-keys/#Usage) on encrypting an api token for `travis-ci` 