### PR TITLE
empecher camera perpendiculaire plan

### DIFF
--- a/Engine/MapEditor/camera.cpp
+++ b/Engine/MapEditor/camera.cpp
@@ -142,5 +142,7 @@ void Camera::zoomLess(int gridHeight){
 
 void Camera::onMouseWheelPressed(QPoint& mouse, QPoint& mouseBeforeUpdate){
     m_height += (mouse.y() - mouseBeforeUpdate.y()) * 2;
+    if(m_height <= 40 && m_height >=0) m_height =-40;
+    else if(m_height >= -40 && m_height <=0) m_height =40;
     m_horizontalAngle += (mouse.x() - mouseBeforeUpdate.x()) / 2;
 }


### PR DESCRIPTION
Dans camera.cpp 
il semblerai que quand m_height est dans  [-20 , 20]    (20 car coeff multiplicateur unnitaire )et que m_distance pas trop grand (cas general) 
le calcul de zommPlus fais que m_distance augmente d'un coup 
Par exemple : peut passer de 220 a 720 d'un coup.
 (notamment dist dans le calcul) , ce qui a pour conséquence que la map "recule" d'un coup et que on ne peux plus zoomerPlus (car m_height =20 et la condition dans la fonction zoomplus empeche de zoomer).
Pour pallier sa une idée est d'empecher l'utilisateur d'etre dans cet intervalle ..