### PR TITLE
Feature/fix commands no selection crash

### DIFF
--- a/CustomWidgets/widgettreecommands.cpp
+++ b/CustomWidgets/widgettreecommands.cpp
@@ -147,8 +147,12 @@ QList<QStandardItem*> WidgetTreeCommands::getAllSelected() const{
 QStandardItem* WidgetTreeCommands::getRootOfCommand(QStandardItem* selected)
 const
 {
-    return (selected->parent() == nullptr) ? p_model->invisibleRootItem()
-                                           : selected->parent();
+    if (selected != nullptr && selected->parent() != nullptr){
+        return selected->parent();
+    }
+    else{
+        return p_model->invisibleRootItem();
+    }
 }
 
 QStandardItemModel *WidgetTreeCommands::getModel() const { return p_model; }
@@ -289,7 +293,17 @@ void WidgetTreeCommands::pasteCommand(QStandardItem* selected){
         copiedCommand = m_copiedCommands.at(i);
         copy = new QStandardItem;
         SystemCommonReaction::copyCommandsItem(copiedCommand, copy);
-        root->insertRow(selected->row(), copy);
+        int insertionRow;
+        if (selected != nullptr){
+            // Insert pasted command just above selection
+            insertionRow = selected->row();
+        }
+        else{
+            // No selection, insert pasted command one row before the end
+            // (to preserve None command at the end)
+            insertionRow = root->rowCount() - 1;
+        }
+        root->insertRow(insertionRow, copy);
         expand(copy->index());
         updateAllNodesString(copy);
     }

--- a/CustomWidgets/widgettreecommands.cpp
+++ b/CustomWidgets/widgettreecommands.cpp
@@ -171,17 +171,8 @@ void WidgetTreeCommands::newCommand(QStandardItem* selected){
     if (dialog.exec() == QDialog::Accepted){
         EventCommand* command = dialog.getCommand();
         QStandardItem* root = getRootOfCommand(selected);
-        int insertionRow;
-        if (selected != nullptr){
-            // Insert pasted command just above selection
-            insertionRow = selected->row();
-        }
-        else{
-            // No selection, insert pasted command one row before the end
-            // (to preserve None command at the end)
-            insertionRow = root->rowCount() - 1;
-        }
-        // post-increment insertionRow to insert command below the initial command row
+        int insertionRow = getInsertionRow(selected, root);
+        // post-increment insertionRow to prepare possible extra row, depending on command kind
         QStandardItem* item = insertCommand(command, root, insertionRow++);
 
         // If event command block, more commands to add...
@@ -304,16 +295,7 @@ void WidgetTreeCommands::pasteCommand(QStandardItem* selected){
         copiedCommand = m_copiedCommands.at(i);
         copy = new QStandardItem;
         SystemCommonReaction::copyCommandsItem(copiedCommand, copy);
-        int insertionRow;
-        if (selected != nullptr){
-            // Insert pasted command just above selection
-            insertionRow = selected->row();
-        }
-        else{
-            // No selection, insert pasted command one row before the end
-            // (to preserve None command at the end)
-            insertionRow = root->rowCount() - 1;
-        }
+        int insertionRow = getInsertionRow(selected, root);
         root->insertRow(insertionRow, copy);
         expand(copy->index());
         updateAllNodesString(copy);
@@ -566,6 +548,18 @@ bool WidgetTreeCommands::itemLessThan(const QStandardItem* item1,
                                       const QStandardItem* item2)
 {
     return item1->row() < item2->row();
+}
+
+int WidgetTreeCommands::getInsertionRow(const QStandardItem* selected, const QStandardItem* root)
+{
+    if (selected != nullptr){
+        // Some rows are selected, new commands should be inserted above
+        return selected->row();
+    }
+    else{
+        // No selection, new commands should be inserted just above the None command at the end
+        return root->rowCount() - 1;
+    }
 }
 
 // -------------------------------------------------------

--- a/CustomWidgets/widgettreecommands.h
+++ b/CustomWidgets/widgettreecommands.h
@@ -80,6 +80,9 @@ protected:
     void selectChildrenOnly(QStandardItem* item);
     static bool itemLessThan(const QStandardItem* item1,
                              const QStandardItem* item2);
+    /// Return the index of the row above current selection.
+    /// If there is no selection, return the index of the last row.
+    static int getInsertionRow(const QStandardItem* selected, const QStandardItem* root);
 
     virtual void keyPressEvent(QKeyEvent *event);
     virtual void mouseDoubleClickEvent(QMouseEvent* event);


### PR DESCRIPTION
This will:
- fix crash when trying to add/paste/edit but selection is empty
- preserve behaviour of add/paste just above selection
- add behaviour of add/paste at the end of all commands when no selection

Remaining bug:
- when there is no selection, <Enter> will not crash but it won't always try to add a new command. More exactly, if the last selected node was a None (empty) command at the end of the root commands list or some sub commands list (e.g. inside an If block), <Enter> will do nothing as it will try to edit the selection, fail the nullptr check and exit without returning any value to inform the caller.