### PR TITLE
[TRAVIS] Install qt511charts on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_install:
       export QT_SHORT="${QT_MAJOR}${QT_MINOR}"              # ex: 511
       sudo add-apt-repository -y ppa:beineri/opt-qt-${QT_FULL}-xenial
       sudo apt-get update -qq
-      sudo apt-get install -qq qt${QT_SHORT}base qt${QT_SHORT}multimedia
+      sudo apt-get install -qq qt${QT_SHORT}base qt${QT_SHORT}multimedia qt${QT_SHORT}charts-no-lgpl
     fi
   - |
     if [ "$CXX" = "clang++" ]; then


### PR DESCRIPTION
Qt Charts is required since WidgetTableProgression has been added in https://github.com/hsandt/rpg-paper-maker/commit/882bb3f8039976c105ceecb42257fe27e1002aa9 which broke Travis build on Linux, so I added the dependency.

Note that Charts is incompatible with LGPL, so we will either have to change license or strip Charts from the project (fortunately only used in this WidgetTableProgression).