### PR TITLE
[CI] Fixed Travis builds on Linux and OSX and test more configurations (all green)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,13 +98,16 @@ install:
 script:
   - qmake -v
   - qmake -r "QMAKE_CXX=$CXX" "QMAKE_CC=$CC"
-  # g++ fails with virtual memory exhausted
-  # when too many processes are running, so don't use -j with it
+  # g++ fails with virtual memory exhausted when too many processes are running
+  # so don't use -j with it in.
+  # In counterpart, `make` on Xenial will take more than 10mn, so to prevent
+  # Travis from shutting down the process, use travis_wait to extend time to 20mn
+  # by logging every minute for that duration.
   - |
     echo "Processors found on virtual machine: ${PROCESSORS}"
     if [ "$CXX" = "g++" ]; then
       echo "g++: do not use parallel jobs to avoid virtual memory exhaustion"
-      make -s
+      travis_wait make -s
     else
       echo "clang: use ${PROCESSORS} parallel jobs"
       make -j${PROCESSORS} -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ before_install:
   - |
     if [ "$TRAVIS_OS_NAME" = "osx" ]; then
       brew update
-      brew install qt${QT_MAJOR} swift
+      brew install qt${QT_MAJOR}
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ env:
   global:
     - MAKEFLAGS="-j 2"
 
+# Linux needs OpenGL
+addons:
+  apt:
+    packages:
+      - libglu1-mesa-dev
+
 # OSX needs to install subversion to use `svn` in update-mods
 addons:
   homebrew:
@@ -12,18 +18,24 @@ addons:
 
 matrix:
   include:
+    # our Qt PPA only supports Qt 5.15.0 on Ubuntu Focus,
+    # which Travis doesn't have yet, so we stick to 5.14.2
     - os: linux
       dist: xenial
       sudo: required
       compiler: gcc
       env:
         - QT_MAJOR=5
-        - QT_MINOR=11
+        - QT_MINOR=14
         - QT_PATCH=2
-      addons:
-        apt:
-          packages:
-            - libglu1-mesa-dev
+    - os: linux
+      dist: bionic
+      sudo: required
+      compiler: gcc
+      env:
+        - QT_MAJOR=5
+        - QT_MINOR=14
+        - QT_PATCH=2
     - os: osx
       osx_image: xcode11.6
       compiler: clang
@@ -44,7 +56,7 @@ before_install:
       export QT_SHORT="${QT_MAJOR}${QT_MINOR}"              # ex: 515
       sudo add-apt-repository -y ppa:beineri/opt-qt-${QT_FULL}-xenial
       sudo apt-get update -qq
-      sudo apt-get install -qq qt${QT_SHORT}base qt${QT_SHORT}multimedia qt${QT_SHORT}multimediawidgets
+      sudo apt-get install -qq qt${QT_SHORT}base qt${QT_SHORT}multimedia
     fi
   - |
     if [ "$TRAVIS_OS_NAME" = "osx" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: cpp
 
 env:
-  global:
-    - MAKEFLAGS="-j 2"
+  linux:
+    - JOBS="$(nproc)"              # should be 2
+  osx:
+    - JOBS="$(sysctl -n hw.ncpu)"  # should be 2
 
 # Linux needs OpenGL
 # `matrix` tends to ignore apt packages defined at the top,
@@ -92,7 +94,7 @@ install:
 script:
   - qmake -v
   - qmake -r "QMAKE_CXX=$CXX" "QMAKE_CC=$CC"
-  - make
+  - make -j${JOBS}
   # Run with X11 display on Linux as some tests require a Qt app
   - |
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ env:
   global:
     - MAKEFLAGS="-j 2"
 
+# OSX needs to install subversion to use `svn` in update-mods
+addons:
+  homebrew:
+    packages:
+    - subversion
+
 matrix:
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: cpp
 
 env:
-  linux:
-    - JOBS="$(nproc)"              # should be 2
-  osx:
-    - JOBS="$(sysctl -n hw.ncpu)"  # should be 2
+  linux: &linux_env
+    - PROCESSORS="$(nproc)"              # should be 2
+  osx: &osx_env
+    - PROCESSORS="$(sysctl -n hw.ncpu)"  # should be 2
 
 # Linux needs OpenGL
 # `matrix` tends to ignore apt packages defined at the top,
@@ -29,6 +29,7 @@ matrix:
       sudo: required
       compiler: gcc
       env:
+        - *linux_env
         - QT_MAJOR=5
         - QT_MINOR=14
         - QT_PATCH=2
@@ -42,6 +43,7 @@ matrix:
       sudo: required
       compiler: gcc
       env:
+        - *linux_env
         - QT_MAJOR=5
         - QT_MINOR=14
         - QT_PATCH=2
@@ -54,12 +56,14 @@ matrix:
       osx_image: xcode11.6
       compiler: clang
       env:
+        - *osx_env
         # current brew stable is 5.15.0
         - QT_MAJOR=5
     - os: osx
       osx_image: xcode12
       compiler: clang
       env:
+        - *osx_env
         # current brew stable is 5.15.0
         - QT_MAJOR=5
 
@@ -97,13 +101,13 @@ script:
   # g++ fails with virtual memory exhausted
   # when too many processes are running, so don't use -j with it
   - |
-    echo "Processors found on virtual machine: ${JOBS}"
+    echo "Processors found on virtual machine: ${PROCESSORS}"
     if [ "$CXX" = "g++" ]; then
       echo "g++: do not use parallel jobs to avoid virtual memory exhaustion"
       make
     else
-      echo "clang: use ${JOBS} parallel jobs"
-      make -j${JOBS}
+      echo "clang: use ${PROCESSORS} parallel jobs"
+      make -j${PROCESSORS}
     fi
   # Run with X11 display on Linux as some tests require a Qt app
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
         - QT_MAJOR=5
         - QT_MINOR=14
         - QT_PATCH=2
+        - DIST=xenial
     - os: linux
       dist: bionic
       sudo: required
@@ -36,6 +37,7 @@ matrix:
         - QT_MAJOR=5
         - QT_MINOR=14
         - QT_PATCH=2
+        - DIST=bionic
     - os: osx
       osx_image: xcode11.6
       compiler: clang
@@ -54,7 +56,7 @@ before_install:
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       export QT_FULL="${QT_MAJOR}.${QT_MINOR}.${QT_PATCH}"  # ex: 5.15.0
       export QT_SHORT="${QT_MAJOR}${QT_MINOR}"              # ex: 515
-      sudo add-apt-repository -y ppa:beineri/opt-qt-${QT_FULL}-xenial
+      sudo add-apt-repository -y ppa:beineri/opt-qt-${QT_FULL}-${DIST}
       sudo apt-get update -qq
       sudo apt-get install -qq qt${QT_SHORT}base qt${QT_SHORT}multimedia
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
 
 before_install:
   - |
-    if [ "$CXX" = "g++" ]; then
+    if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       export QT_FULL="${QT_MAJOR}.${QT_MINOR}.${QT_PATCH}"  # ex: 5.15.0
       export QT_SHORT="${QT_MAJOR}${QT_MINOR}"              # ex: 515
       sudo add-apt-repository -y ppa:beineri/opt-qt-${QT_FULL}-xenial
@@ -47,7 +47,7 @@ before_install:
       sudo apt-get install -qq qt${QT_SHORT}base qt${QT_SHORT}multimedia qt${QT_SHORT}multimediawidgets
     fi
   - |
-    if [ "$CXX" = "clang++" ]; then
+    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
       brew update
       brew install qt${QT_MAJOR} swift
     fi
@@ -56,11 +56,11 @@ install:
   - export QT_SELECT=qt${QT_MAJOR}
   - $CXX --version
   - |
-    if [ "$CXX" = "g++" ]; then
+    if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       . /opt/qt${QT_SHORT}/bin/qt${QT_SHORT}-env.sh
     fi
   - |
-    if [ "$CXX" = "clang++" ]; then
+    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
       brew link --force qt${QT_MAJOR}
     fi
   - ./update-mods
@@ -71,7 +71,7 @@ script:
   - make
   # Run with X11 display on Linux as some tests require a Qt app
   - |
-    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+    if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       xvfb-run make -k check
     else
       make -k check

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ env:
     - MAKEFLAGS="-j 2"
 
 # Linux needs OpenGL
+# `matrix` tends to ignore apt packages defined at the top,
+# so define a list here and reference it in each linux config
 addons:
   apt:
-    packages:
+    packages: &linux_packages
       - libglu1-mesa-dev
 
 # OSX needs to install subversion to use `svn` in update-mods
@@ -29,6 +31,10 @@ matrix:
         - QT_MINOR=14
         - QT_PATCH=2
         - DIST=xenial
+      addons:
+        apt:
+          packages:
+            - *linux_packages
     - os: linux
       dist: bionic
       sudo: required
@@ -38,6 +44,10 @@ matrix:
         - QT_MINOR=14
         - QT_PATCH=2
         - DIST=bionic
+      addons:
+        apt:
+          packages:
+            - *linux_packages
     - os: osx
       osx_image: xcode11.6
       compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: cpp
 
-osx_image: xcode10.1
-
 env:
   global:
     - MAKEFLAGS="-j 2"
@@ -21,16 +19,23 @@ matrix:
           packages:
             - libglu1-mesa-dev
     - os: osx
+      osx_image: xcode11.6
       compiler: clang
       env:
-        # current brew stable is 5.11.2
+        # current brew stable is 5.15.0
+        - QT_MAJOR=5
+    - os: osx
+      osx_image: xcode12
+      compiler: clang
+      env:
+        # current brew stable is 5.15.0
         - QT_MAJOR=5
 
 before_install:
   - |
     if [ "$CXX" = "g++" ]; then
-      export QT_FULL="${QT_MAJOR}.${QT_MINOR}.${QT_PATCH}"  # ex: 5.11.2
-      export QT_SHORT="${QT_MAJOR}${QT_MINOR}"              # ex: 511
+      export QT_FULL="${QT_MAJOR}.${QT_MINOR}.${QT_PATCH}"  # ex: 5.15.0
+      export QT_SHORT="${QT_MAJOR}${QT_MINOR}"              # ex: 515
       sudo add-apt-repository -y ppa:beineri/opt-qt-${QT_FULL}-xenial
       sudo apt-get update -qq
       sudo apt-get install -qq qt${QT_SHORT}base qt${QT_SHORT}multimedia qt${QT_SHORT}multimediawidgets

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,17 @@ install:
 script:
   - qmake -v
   - qmake -r "QMAKE_CXX=$CXX" "QMAKE_CC=$CC"
-  - make -j${JOBS}
+  # g++ fails with virtual memory exhausted
+  # when too many processes are running, so don't use -j with it
+  - |
+    echo "Processors found on virtual machine: ${JOBS}"
+    if [ "$CXX" = "g++" ]; then
+      echo "g++: do not use parallel jobs to avoid virtual memory exhaustion"
+      make
+    else
+      echo "clang: use ${JOBS} parallel jobs"
+      make -j${JOBS}
+    fi
   # Run with X11 display on Linux as some tests require a Qt app
   - |
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,10 +104,10 @@ script:
     echo "Processors found on virtual machine: ${PROCESSORS}"
     if [ "$CXX" = "g++" ]; then
       echo "g++: do not use parallel jobs to avoid virtual memory exhaustion"
-      make
+      make -s
     else
       echo "clang: use ${PROCESSORS} parallel jobs"
-      make -j${PROCESSORS}
+      make -j${PROCESSORS} -s
     fi
   # Run with X11 display on Linux as some tests require a Qt app
   - |

--- a/Test/test_widgettreecommands.cpp
+++ b/Test/test_widgettreecommands.cpp
@@ -12,6 +12,9 @@
 
 #include "widgettreecommands.h"
 
+// only required to initialize localization strings
+#include "rpm.h"
+
 class TestWidgetTreeCommands : public QObject
 {
     Q_OBJECT
@@ -48,6 +51,12 @@ void TestWidgetTreeCommands::cleanupTestCase()
 
 void TestWidgetTreeCommands::test_initializeModel_noSelection()
 {
+    // WidgetTreeCommands constructor calls initializeCommandsList
+    // which calls EventCommand::kindToString which requires localized strings to be ready.
+    // Until this setup phase is extracted from WidgetTreeCommands constructor or
+    // EventCommand::kindToString is made robust against invalid keys, we must init the strings now.
+    RPM::get()->readTranslations();
+
     WidgetTreeCommands dummyWidgetTree;
     QStandardItemModel dummyModel;
 

--- a/update-mods
+++ b/update-mods
@@ -22,7 +22,7 @@ else
 fi
 path='../Game-Scripts/main.js'
 pathModsMain="${modsPath}/main.js"
-if [ $path ]; then
+if [ -f $path ]; then
 	echo "$localMessage $path $moveSymbol $pathModsMain"
 	cp -r $path $pathModsMain
 else
@@ -32,7 +32,7 @@ else
 fi
 path='../Game-Scripts/index.html'
 pathModsIndex="${modsPath}/index.html"
-if [ $path ]; then
+if [ -f $path ]; then
 	echo "$localMessage $path $moveSymbol $pathModsIndex"
 	cp -r $path $pathModsIndex
 else
@@ -42,7 +42,7 @@ else
 fi
 path='../Game-Scripts/package.json'
 pathModsPackage="${modsPath}/package.json"
-if [ $path ]; then
+if [ -f $path ]; then
 	echo "$localMessage $path $moveSymbol $pathModsPackage"
 	cp -r $path $pathModsPackage
 else


### PR DESCRIPTION
For pre-build:
- fixed update-mods

For actual build:
- use latest OSX images with Xcode11 and Xcode12, added Ubuntu Bionic (there are now 4 builds instead of 2)
- fix OSX specific issues: install svn
- upgraded Qt version to latest possible on our Linux PPA with Xenial and Bionic (5.14.2)

For build optimization:
- OSX doesn't install swift anymore (provided in image)
- OSX uses make -j 2 (unfortunately Xenial had not enough memory to do so, so I just make on Linux; Bionic could make -j 2 if we really want; note that times are currently not better on OSX side, but it may be specific to that platform)

Finally, to pass unit tests:
- initialize localization strings before construction WidgetTreeCommands